### PR TITLE
Fix instant now() from web workers using wasm-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,27 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 now = [ "time" ]
-wasm-bindgen = ["web-sys"]
+wasm-bindgen = ["js-sys", "wasm-bindgen_rs", "web-sys"]
 
 [target.'cfg(not(any(feature = "stdweb", feature = "wasm-bindgen")))'.dependencies]
 time = { version = "0.1", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
+js-sys = { version = "0.3", optional = true }
 stdweb = { version = "0.4", optional = true }
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2", optional = true }
 web-sys = { version = "0.3", optional = true, features = ['Window', 'Performance', 'PerformanceTiming'] }
 
 [target.wasm32-unknown-emscripten.dependencies]
+js-sys = { version = "0.3", optional = true }
 stdweb = { version = "0.4", optional = true }
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2", optional = true }
 web-sys = { version = "0.3", optional = true, features = ['Window', 'Performance', 'PerformanceTiming'] }
 
 [target.asmjs-unknown-emscripten.dependencies]
+js-sys = { version = "0.3", optional = true }
 stdweb = { version = "0.4", optional = true }
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2", optional = true }
 web-sys = { version = "0.3", optional = true, features = ['Window', 'Performance', 'PerformanceTiming'] }
 
 [dev-dependencies]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -95,9 +95,10 @@ pub fn now() -> f64 {
 
 #[cfg(feature = "wasm-bindgen")]
 pub fn now() -> f64 {
-    web_sys::window()
-        .expect("should have a window in this context")
-        .performance()
-        .expect("performance should be available")
-        .now()
+    use wasm_bindgen_rs::JsCast;
+    use wasm_bindgen_rs::prelude::*;
+    js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("performance"))
+        .expect("failed to get performance from global object")
+	.unchecked_into::<web_sys::Performance>()
+	.now()
 }


### PR DESCRIPTION
Gets `web_sys::Performance` directly from `js_sys::global()` rather than using `web_sys::window()` so that it works with web workers as well as from the main thread. 

The current implementation of `web_sys::window()` (https://rustwasm.github.io/wasm-bindgen/api/src/web_sys/lib.rs.html#31) is:
```
use wasm_bindgen::JsCast;

js_sys::global().dyn_into::<Window>().ok
```

There is not currently any `web_sys` type available to represent the `WindowOrWorkerGlobalScope` mixin (see https://www.w3.org/TR/hr-time-2/#the-performance-attribute), but a `performance` attribute will be available on the global scope in either situation. 

This implementation gets the Object from the `performance` attribute and casts it directly to `web_sys::Performance` and then calls `now()` on that as before. 

I have run the wasm-pack-test using headless chrome and can confirm that this still works with a global `Window` scope. I have also (manually) tested it in a web worker in chrome and can confirm it works in that scope as well. It would be nice if there was an easy way to test wasm libraries in a web worker context, but wasm-pack-test does not appear to support that yet. 

Fixes #11 