### PR TITLE
Use an `extern "C"` now function that can be bound in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as long as you are not targeting wasm32. This allows for portable code that will
 ### The feature `now`.
 By enabling the feature `now` the function `instant::now()` will be exported and will either:
 
-* Call `performance.now()` when compiling for a WASM platform with the features **stdweb** or **wasm-bindgen** enabled.
+* Call `performance.now()` when compiling for a WASM platform with the features **stdweb** or **wasm-bindgen** enabled, or using a custom javascript function.
 * Call `time::precise_time_s() * 1000.0` otherwise.
 
 The result is expressed in milliseconds.
@@ -97,5 +97,28 @@ fn my_function() {
     // feature selected by the user.
     let now_instant = instant::Instant::new();
     let now_milliseconds = instant::now(); // In milliseconds.
+}
+```
+
+### Using the feature `now` without `stdweb` or `wasm-bindgen`.
+_Cargo.toml_:
+```toml
+[dependencies]
+instant = { version = "0.", features = [ "now" ] }
+```
+
+_lib.rs_:
+```rust
+fn my_function() {
+    // Will use the 'now' javascript implementation.
+    let now_instant = instant::Instant::new();
+    let now_milliseconds = instant::now(); // In milliseconds.
+}
+```
+
+_javascript WASM bindings file_:
+```js
+function now() {
+	return Date.now() / 1000.0;
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,41 +2,23 @@
 #[macro_use]
 extern crate stdweb;
 
-#[cfg(any(
-    not(any(target_arch = "wasm32", target_arch = "asmjs")),
-    not(any(feature = "stdweb", feature = "wasm-bindgen"))
-))]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 pub use crate::native::Instant;
 
-#[cfg(all(
-    any(target_arch = "wasm32", target_arch = "asmjs"),
-    any(feature = "stdweb", feature = "wasm-bindgen")
-))]
+#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 pub use crate::wasm::Instant;
 
-#[cfg(any(
-    not(any(target_arch = "wasm32", target_arch = "asmjs")),
-    not(any(feature = "stdweb", feature = "wasm-bindgen"))
-))]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 #[cfg(feature = "now")]
 pub use crate::native::now;
 
-#[cfg(all(
-    any(target_arch = "wasm32", target_arch = "asmjs"),
-    any(feature = "stdweb", feature = "wasm-bindgen")
-))]
+#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 #[cfg(feature = "now")]
 pub use crate::wasm::now;
 
 pub use std::time::Duration;
 
-#[cfg(any(
-    not(any(target_arch = "wasm32", target_arch = "asmjs")),
-    not(any(feature = "stdweb", feature = "wasm-bindgen"))
-))]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 mod native;
-#[cfg(all(
-    any(target_arch = "wasm32", target_arch = "asmjs"),
-    any(feature = "stdweb", feature = "wasm-bindgen")
-))]
+#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 mod wasm;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -95,10 +95,23 @@ pub fn now() -> f64 {
 
 #[cfg(feature = "wasm-bindgen")]
 pub fn now() -> f64 {
-    use wasm_bindgen_rs::JsCast;
     use wasm_bindgen_rs::prelude::*;
+    use wasm_bindgen_rs::JsCast;
     js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("performance"))
         .expect("failed to get performance from global object")
-	.unchecked_into::<web_sys::Performance>()
-	.now()
+        .unchecked_into::<web_sys::Performance>()
+        .now()
+}
+
+// The JS now function is in a module so it won't have to be renamed
+#[cfg(not(any(feature = "wasm-bindgen", feature = "stdweb")))]
+mod js {
+    extern "C" {
+        pub fn now() -> f64;
+    }
+}
+// Make the unsafe extern function "safe" so it can be called like the other 'now' functions
+#[cfg(not(any(feature = "wasm-bindgen", feature = "stdweb")))]
+pub fn now() -> f64 {
+    unsafe { js::now() }
 }


### PR DESCRIPTION
I'm trying to get the nphysics library to run in WASM, but the platform I'm using to do this ([miniquad](https://github.com/not-fl3/miniquad)) uses neither stdweb nor wasm-bindgen. As a result instant's `now` function panics during runtime.

This PR allows framework/platform creators that don't use stdweb or wasm-bindgen to still use the `now` feature by exposing their own function in JavaScript.