### PR TITLE
Adds `checked_add` and `checked_sub` to `wasm::Instant`.

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -31,6 +31,22 @@ impl Instant {
     pub fn elapsed(&self) -> Duration {
         Self::now().duration_since(*self)
     }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[inline]
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_add(duration).map(Instant)
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[inline]
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_sub(duration).map(Instant)
+    }
 }
 
 impl Add<Duration> for Instant {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -19,3 +19,28 @@ fn test_duration() {
     let one_sec = Duration::from_secs(1);
     assert!(now.elapsed() < one_sec);
 }
+
+// Duration::new will overflow when you have u64::MAX seconds and one billion nanoseconds.
+// <https://doc.rust-lang.org/std/time/struct.Duration.html#method.new>
+const ONE_BILLION: u32 = 1_000_000_000;
+
+#[wasm_bindgen_test]
+fn test_checked_add() {
+    let now = Instant::now();
+
+    assert!(now.checked_add(Duration::from_millis(1)).is_some());
+    assert_eq!(
+        None,
+        now.checked_add(Duration::new(u64::MAX, ONE_BILLION - 1))
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_checked_sub() {
+    let now = Instant::now();
+
+    assert!(now.checked_sub(Duration::from_millis(1)).is_some());
+    assert!(now
+        .checked_sub(Duration::new(u64::MAX, ONE_BILLION - 1))
+        .is_none());
+}


### PR DESCRIPTION
Closes #16.