### PR TITLE
Make `wasm-bindgen` feature override `stdweb`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#[cfg(all(any(target_arch = "wasm32", target_arch = "asmjs"), feature = "stdweb"))]
+#[cfg(all(
+    any(target_arch = "wasm32", target_arch = "asmjs"),
+    all(feature = "stdweb", not(feature = "wasm-bindgen"))
+))]
 #[macro_use]
 extern crate stdweb;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -99,7 +99,7 @@ fn duration_to_f64(d: Duration) -> f64 {
     d.as_secs() as f64 * 1.0e3 + f64::from(d.subsec_nanos()) * 1.0e-6
 }
 
-#[cfg(feature = "stdweb")]
+#[cfg(all(feature = "stdweb", not(feature = "wasm-bindgen")))]
 #[allow(unused_results)] // Needed because the js macro triggers it.
 pub fn now() -> f64 {
     use stdweb::unstable::TryInto;


### PR DESCRIPTION
... instead of trying to include both versions of the now() function in
the build.

Fixes: #23