### PR TITLE
Remove dependency on obsolete `time` 0.2 and deprecate the `now` feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,12 @@ keywords = [ "time", "wasm" ]
 edition = "2018"
 
 [features]
-now = [ "time" ]
 wasm-bindgen = ["js-sys", "wasm-bindgen_rs", "web-sys"]
 inaccurate = []
+now = []
 
 [dependencies]
 cfg-if = "1.0"
-
-[target.'cfg(not(any(feature = "stdweb", feature = "wasm-bindgen")))'.dependencies]
-time = { version = "0.2", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ replacement for `std::time::Instant` that works on WASM too. This defines the ty
 Note that even if the **stdweb** or **wasm-bindgen** feature is enabled, this crate will continue to rely on `std::time::Instant`
 as long as you are not targeting wasm32. This allows for portable code that will work on both native and WASM platforms.
 
-### The feature `now`.
-By enabling the feature `now` the function `instant::now()` will be exported and will either:
+This crate also exports the function `instant::now()` which returns a representation of the current time as an `f64`, expressed in milliseconds, in a platform-agnostic way. `instant::now()` will either:
 
 * Call `performance.now()` when compiling for a WASM platform with the features **stdweb** or **wasm-bindgen** enabled, or using a custom javascript function.
-* Call `time::precise_time_s() * 1000.0` otherwise.
+* Return the time elapsed since the *Unix Epoch* on *native*, *non-WASM* platforms.
 
-The result is expressed in milliseconds.
+*Note*: The old feature, `now`, has been deprecated. `instant::now()` is always exported and the `now` feature flag no longer has any effect. It remains listed in `Cargo.toml` to avoid introducing breaking changes and may be removed in future versions.
 
 ## Examples
 ### Using `instant` for a native platform.
@@ -99,7 +98,7 @@ fn my_function() {
 
 -----
 
-### Using the feature `now`.
+### Using `instant::now()`
 _Cargo.toml_:
 ```toml
 [features]
@@ -107,7 +106,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-instant = { version = "0.1", features = [ "now" ] }
+instant = "0.1"
 ```
 
 _lib.rs_:
@@ -124,7 +123,7 @@ fn my_function() {
 _Cargo.toml_:
 ```toml
 [dependencies]
-instant = { version = "0.", features = [ "now" ] }
+instant = "0.1"
 ```
 
 _lib.rs_:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,10 @@ cfg_if::cfg_if! {
 
         mod wasm;
         pub use wasm::Instant;
-        #[cfg(feature = "now")]
         pub use crate::wasm::now;
     } else {
         mod native;
         pub use native::Instant;
-        #[cfg(feature = "now")]
         pub use native::now;
     }
 }

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,7 +1,6 @@
 pub type Instant = std::time::Instant;
 
 /// The current time, expressed in milliseconds since the Unix Epoch.
-#[cfg(feature = "now")]
 pub fn now() -> f64 {
     std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
                                 .expect("System clock was before 1970.")

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,7 +1,9 @@
 pub type Instant = std::time::Instant;
 
-/// The current time, in milliseconds.
+/// The current time, expressed in milliseconds since the Unix Epoch.
 #[cfg(feature = "now")]
 pub fn now() -> f64 {
-    time::precise_time_s() * 1000.0
+    std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+                                .expect("System clock was before 1970.")
+                                .as_secs_f64() * 1000.0
 }


### PR DESCRIPTION
On *non-WASM* targets, `instant` has an optional dependency on an obsolete build of the `time` crate (version 0.2) if the `now` feature is enabled, all to get the use of `time::precise_time_s()` which is just a one-liner, calling `std::time::SystemTime`, which is in `std`, anyway. `time::precise_time_s()` is also deprecated and, presumably because `now` adds the extra burden of a dependency on the `time` crate, `now` is an optional feature.

This merge request:

- Inlines the trivial implementation of `time::precise_time_s()` into `instant::native::now()`
  - It's trivial and relies only on `std`: https://docs.rs/time/0.2.27/src/time/lib.rs.html#547-553
  - It's deprecated in `time`, anyway, and gone in 0.3 and up.
  - It removes the obsolete `time` 0.2 dependency.

- Deprecates the `now` feature, making `instant::now()` always available, not optional.
  - Simplifies the usage notes for `instant`.
  - No longer imposes any cost at all, since it adds no dependencies.
  - `now` is still defined in `Cargo.toml` to avoid breaking changes -- a deprecation notice has been added to the README

This merge request will resolve issues #40 and #32.