### PR TITLE
emscripten_get_now should have no leading underscore

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -150,7 +150,7 @@ mod js {
         #[cfg(not(target_os = "emscripten"))]
         pub fn now() -> f64;
         #[cfg(target_os = "emscripten")]
-        pub fn _emscripten_get_now() -> f64;
+        pub fn emscripten_get_now() -> f64;
     }
 }
 // Make the unsafe extern function "safe" so it can be called like the other 'now' functions
@@ -159,7 +159,7 @@ pub fn now() -> f64 {
     #[cfg(not(target_os = "emscripten"))]
     return unsafe { js::now() };
     #[cfg(target_os = "emscripten")]
-    return unsafe { js::_emscripten_get_now() };
+    return unsafe { js::emscripten_get_now() };
 }
 
 /// Returns the number of millisecods elapsed since January 1, 1970 00:00:00 UTC.


### PR DESCRIPTION
According to @sbc100 in https://github.com/emscripten-core/emscripten/issues/17106#issuecomment-1143836563 `emscripten_core:

> It looks like that side module is trying to import this symbol with an `_` prefix.   But that symbol doesn't start with an underscore:
>
> https://github.com/emscripten-core/emscripten/blob/922cf56100de7dd162593f64481c73d16931643e/system/include/emscripten/emscripten.h#L86

See https://github.com/emscripten-core/emscripten/issues/17106

I have confirmed that this fix works on 
https://github.com/pyodide/pyodide/pull/2378
though it requires an additional patch to Emscripten to add a signature for `emscripten_get_now` (see linked Emscripten issue). This additional Emscripten patch is only needed to use `instant` in a dynamically linked side module, if it's in the main module it is unnecessary.
