### PR TITLE
Add support for #![no_std]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,3 +31,6 @@ jobs:
       - run:
           name: build --features now wasm-bindgen
           command: cargo build --verbose --target wasm32-unknown-unknown --features "now wasm-bindgen";
+      - run:
+          name: build --no-default-features
+          command: cargo build --verbose --no-default-features;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.13
+
+## Added
+- Add enabled by default `std` feature which can be disabled to use this crate in `#![no_std]`  crates
+
 # v0.1.12
 ## Added 
 - Add `SystemTime` which works in both native and WASM environments.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,20 @@
 [package]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["sebcrozet <developer@crozet.re>"]
-description = "A partial replacement for std::time::Instant that works on WASM too."
+description = "A partial replacement for std::time::Instant that works on no_std and WASM too."
 repository = "https://github.com/sebcrozet/instant"
 readme = "README.md"
 license = "BSD-3-Clause"
-keywords = [ "time", "wasm" ]
+keywords = [ "time", "wasm", "no_std" ]
 edition = "2018"
 
 [features]
 wasm-bindgen = ["js-sys", "wasm-bindgen_rs", "web-sys"]
 inaccurate = []
 now = []
+std = []
+default = ["std"]
 
 [dependencies]
 cfg-if = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Instant
 
+`std::time::Instant` does not exist for `#[no_std]` target.
 If you call `std::time::Instant::now()` on a WASM platform, it will panic. This crate provides a partial
-replacement for `std::time::Instant` that works on WASM too. This defines the type `instant::Instant` which is:
+replacement for `std::time::Instant` that works on `#[no_std]` and WASM too. 
+This defines the type `instant::Instant` which is:
 
+* A struct emulating the behavior of **std::time::Instant** if you disabled the feature `std`. A constructor function `Instant::drom_duration`
+  is provided to construct an instant from a `core::time::Duration`.
 * A struct emulating the behavior of **std::time::Instant** if you are targeting `wasm32-unknown-unknown` or `wasm32-unknown-asmjs`
 **and** you enabled either the `stdweb` or the `wasm-bindgen` feature. This emulation is based on the javascript `performance.now()` function.
 * A type alias for `std::time::Instant` otherwise.
 
-
-
 Note that even if the **stdweb** or **wasm-bindgen** feature is enabled, this crate will continue to rely on `std::time::Instant`
 as long as you are not targeting wasm32. This allows for portable code that will work on both native and WASM platforms.
 
-This crate also exports the function `instant::now()` which returns a representation of the current time as an `f64`, expressed in milliseconds, in a platform-agnostic way. `instant::now()` will either:
+With the `std` feature (enabled by default), this crate also exports the function `instant::now()` which returns a representation of the current time as an `f64`,
+expressed in milliseconds, in a platform-agnostic way. `instant::now()` will either:
 
 * Call `performance.now()` when compiling for a WASM platform with the features **stdweb** or **wasm-bindgen** enabled, or using a custom javascript function.
 * Return the time elapsed since the *Unix Epoch* on *native*, *non-WASM* platforms.

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,0 +1,105 @@
+use core::cmp::Ordering;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::time::Duration;
+
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Hash)]
+pub struct Instant(pub(crate) Duration);
+
+impl Ord for Instant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other)
+            .expect("an instant should never be NaN or Inf.")
+    }
+}
+impl Eq for Instant {}
+
+impl Instant {
+    #[inline]
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[inline]
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_add(duration).map(Instant)
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[inline]
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_sub(duration).map(Instant)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or None if that
+    /// instant is later than this one.
+    #[inline]
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        if earlier.0 > self.0 {
+            None
+        } else {
+            Some(self.0 - earlier.0)
+        }
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or zero duration if
+    /// that instant is later than this one.
+    #[inline]
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Create an Instant that represent the instant of the given duration since the beginning of time.
+    ///
+    /// Only available if the feature std is not enabled
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    pub fn from_duration(duration: Duration) -> Self {
+        Self(duration)
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Duration) -> Self {
+        Instant(self.0 + rhs)
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    #[inline]
+    fn add_assign(&mut self, rhs: Duration) {
+        self.0 += rhs
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Duration) -> Self {
+        Instant(self.0 - rhs)
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    #[inline]
+    fn sub(self, rhs: Instant) -> Duration {
+        self.duration_since(rhs)
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Duration) {
+        self.0 -= rhs
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 cfg_if::cfg_if! {
-    if #[cfg(any(
+    if #[cfg(not(feature = "std"))] {
+        mod instant;
+        pub use crate::instant::Instant;
+    } else if #[cfg(any(
         all(target_arch = "wasm32", not(target_os = "wasi")),
         target_arch = "asmjs"
     ))] {
@@ -7,8 +12,9 @@ cfg_if::cfg_if! {
         #[macro_use]
         extern crate stdweb;
 
+        mod instant;
+        pub use crate::instant::Instant;
         mod wasm;
-        pub use wasm::Instant;
         pub use crate::wasm::now;
         pub use wasm::SystemTime;
     } else {
@@ -19,4 +25,4 @@ cfg_if::cfg_if! {
     }
 }
 
-pub use std::time::Duration;
+pub use core::time::Duration;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,17 +1,6 @@
-use std::cmp::Ordering;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-use std::time::Duration;
-
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Hash)]
-pub struct Instant(Duration);
-
-impl Ord for Instant {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other)
-            .expect("an instant should never be NaN or Inf.")
-    }
-}
-impl Eq for Instant {}
+use crate::instant::Instant;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::time::Duration;
 
 impl Instant {
     #[inline]
@@ -20,92 +9,8 @@ impl Instant {
     }
 
     #[inline]
-    pub fn duration_since(&self, earlier: Instant) -> Duration {
-        assert!(
-            earlier.0 <= self.0,
-            "`earlier` cannot be later than `self`."
-        );
-        self.0 - earlier.0
-    }
-
-    #[inline]
     pub fn elapsed(&self) -> Duration {
         Self::now().duration_since(*self)
-    }
-
-    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
-    #[inline]
-    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_add(duration).map(Instant)
-    }
-
-    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
-    #[inline]
-    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_sub(duration).map(Instant)
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one, or None if that
-    /// instant is later than this one.
-    #[inline]
-    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
-        if earlier.0 > self.0 {
-            None
-        } else {
-            Some(self.0 - earlier.0)
-        }
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one, or zero duration if
-    /// that instant is later than this one.
-    #[inline]
-    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
-        self.checked_duration_since(earlier).unwrap_or_default()
-    }
-}
-
-impl Add<Duration> for Instant {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, rhs: Duration) -> Self {
-        Instant(self.0 + rhs)
-    }
-}
-
-impl AddAssign<Duration> for Instant {
-    #[inline]
-    fn add_assign(&mut self, rhs: Duration) {
-        self.0 += rhs
-    }
-}
-
-impl Sub<Duration> for Instant {
-    type Output = Self;
-
-    #[inline]
-    fn sub(self, rhs: Duration) -> Self {
-        Instant(self.0 - rhs)
-    }
-}
-
-impl Sub<Instant> for Instant {
-    type Output = Duration;
-
-    #[inline]
-    fn sub(self, rhs: Instant) -> Duration {
-        self.duration_since(rhs)
-    }
-}
-
-impl SubAssign<Duration> for Instant {
-    #[inline]
-    fn sub_assign(&mut self, rhs: Duration) {
-        self.0 -= rhs
     }
 }
 

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 extern crate wasm_bindgen_test;
 
 use instant::{Instant, SystemTime};


### PR DESCRIPTION
I'm working in a library that should be used on wasm and also on MCU platform with #[no_std].
I thought this crate would be a good fit to also have an Instant that can also work in `#[no_std].`

This allow to use Instant in no_std crate.
Added a `Instant::from_duration `that can be used to construct an instant
from a Duration when not using the Rust std lib

What do you think?